### PR TITLE
cmake: use the `find_package` name at `find_package` time

### DIFF
--- a/CMake/Config.cmake.in
+++ b/CMake/Config.cmake.in
@@ -1,4 +1,4 @@
 
 @PACKAGE_INIT@
 
-include ( "${CMAKE_CURRENT_LIST_DIR}/${PROJECT_NAME}-targets.cmake" )
+include ( "${CMAKE_CURRENT_LIST_DIR}/${CMAKE_FIND_PACKAGE_NAME}-targets.cmake" )


### PR DESCRIPTION
The `PROJECT_NAME` variable is the end-project at this point.